### PR TITLE
Remove role field from signup form and update hooks

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -58,12 +58,12 @@ export const useLoginWithGoogle = () =>
     }
   })
 
-export const useSignup = () =>
+export const useUserSignupWithEmail = () =>
   useMutation({
     mutationFn: authService.signUp
   })
 
-export const useSignupWithGoogle = () =>
+export const useUserSignupWithGoogle = () =>
   useMutation({
     mutationFn: async () => {
       // Temporary implementation until Google OAuth is implemented

--- a/src/pages/auth/Signup/Form/fields.js
+++ b/src/pages/auth/Signup/Form/fields.js
@@ -3,16 +3,14 @@ const FieldName = {
   LAST_NAME: 'lastName',
   EMAIL: 'email',
   PASSWORD: 'password',
-  ROLE: 'role',
   CAPTCHA_TOKEN: 'captchaToken'
 }
 
-const getDefaultValues = role => ({
+const getDefaultValues = () => ({
   [FieldName.FIRST_NAME]: '',
   [FieldName.LAST_NAME]: '',
   [FieldName.EMAIL]: '',
   [FieldName.PASSWORD]: '',
-  [FieldName.ROLE]: role,
   [FieldName.CAPTCHA_TOKEN]: ''
 })
 

--- a/src/pages/auth/Signup/Form/index.jsx
+++ b/src/pages/auth/Signup/Form/index.jsx
@@ -8,7 +8,6 @@ import FormField from '@/components/form/Field'
 import { PasswordInput, TextInput } from '@/components/inputs'
 import InvisibleReCaptcha2 from '@/components/InvisibleReCaptcha2'
 import useLocale from '@/hooks/useLocale'
-import { Role } from '@/lib/types'
 
 import { FieldName, getDefaultValues } from './fields'
 import resolver from './resolver'
@@ -23,7 +22,7 @@ const SignupForm = ({ onSubmit, isLoading = false }) => {
     formState: { errors, isSubmitting }
   } = useForm({
     resolver,
-    defaultValues: getDefaultValues(Role.USER)
+    defaultValues: getDefaultValues()
   })
 
   const handleSubmitForm = async data => {

--- a/src/pages/auth/Signup/Form/index.test.js
+++ b/src/pages/auth/Signup/Form/index.test.js
@@ -204,7 +204,6 @@ describe('Signup Form', () => {
         expect(onSubmitMock).toHaveBeenCalledWith(
           expect.objectContaining({
             email: auth.email.ok,
-            role: 'user',
             captchaToken: auth.captcha.valid
           })
         )
@@ -264,7 +263,6 @@ describe('Signup Form', () => {
             firstName: auth.firstName.ok,
             email: auth.email.ok,
             password: auth.password.strong,
-            role: 'user',
             captchaToken: auth.captcha.alternative
           })
         )
@@ -273,7 +271,7 @@ describe('Signup Form', () => {
   })
 
   describe('Form Submission', () => {
-    it('includes role field with user value in submission', async () => {
+    it('does not include role field in submission', async () => {
       global.mockExecuteReCaptcha.mockResolvedValue(auth.captcha.valid)
       const onSubmitMock = jest.fn()
       const { firstNameInput, emailInput, passwordInput, submitButton } =
@@ -286,8 +284,8 @@ describe('Signup Form', () => {
 
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            role: 'user'
+          expect.not.objectContaining({
+            role: expect.anything()
           })
         )
       })
@@ -314,7 +312,6 @@ describe('Signup Form', () => {
             firstName: auth.firstName.ok,
             email: auth.email.ok,
             password: auth.password.strong,
-            role: 'user',
             captchaToken: auth.captcha.valid
           })
         )
@@ -346,7 +343,6 @@ describe('Signup Form', () => {
             lastName: auth.lastName.ok,
             email: auth.email.ok,
             password: auth.password.strong,
-            role: 'user',
             captchaToken: auth.captcha.alternative
           })
         )
@@ -371,7 +367,6 @@ describe('Signup Form', () => {
             firstName: auth.firstName.ok,
             email: auth.email.ok,
             password: auth.password.strong,
-            role: 'user',
             captchaToken: auth.captcha.alternative
           })
         )

--- a/src/pages/auth/Signup/index.jsx
+++ b/src/pages/auth/Signup/index.jsx
@@ -5,7 +5,10 @@ import { useNavigate } from 'react-router-dom'
 import { GoogleOAuthButton } from '@/components/buttons'
 import { LoginPrompt, TermsAndPrivacyPrompt } from '@/components/prompts'
 import Separator from '@/components/Separator'
-import { useSignup, useSignupWithGoogle } from '@/hooks/useAuth'
+import {
+  useUserSignupWithEmail,
+  useUserSignupWithGoogle
+} from '@/hooks/useAuth'
 import useLocale from '@/hooks/useLocale'
 import useNotifications from '@/hooks/useNotifications'
 import { toTranslationKey } from '@/services/catch'
@@ -16,9 +19,10 @@ const Signup = () => {
   const { t } = useLocale()
   const navigate = useNavigate()
   const { showErrorToast } = useNotifications()
-  const { mutate: signUpWithEmail, isPending: isEmailPending } = useSignup()
+  const { mutate: signUpWithEmail, isPending: isEmailPending } =
+    useUserSignupWithEmail()
   const { mutate: signUpWithGoogle, isPending: isGooglePending } =
-    useSignupWithGoogle()
+    useUserSignupWithGoogle()
 
   const handleSignupWithEmail = data => {
     if (!data.captchaToken) {


### PR DESCRIPTION
Eliminates the 'role' field from the signup form, its default values, and related tests. Renames signup hooks for clarity and updates their usage throughout the signup flow to reflect the new naming.