### PR TITLE
Add tests for Sidebar components

### DIFF
--- a/src/components/Sidebar/ActiveIndicator/index.test.jsx
+++ b/src/components/Sidebar/ActiveIndicator/index.test.jsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+
+import ActiveIndicator from './index'
+
+describe('ActiveIndicator', () => {
+  it('renders without variant', () => {
+    const { container } = render(<ActiveIndicator />)
+
+    const indicator = container.querySelector('.active-indicator')
+
+    expect(indicator).toBeInTheDocument()
+  })
+
+  it('renders with item variant', () => {
+    const { container } = render(<ActiveIndicator variant='item' />)
+
+    const indicator = container.querySelector('.active-indicator')
+
+    expect(indicator).toHaveClass('active-indicator--item')
+  })
+
+  it('renders with sub-item variant', () => {
+    const { container } = render(<ActiveIndicator variant='sub-item' />)
+
+    const indicator = container.querySelector('.active-indicator')
+
+    expect(indicator).toHaveClass('active-indicator--sub-item')
+  })
+})

--- a/src/components/Sidebar/Item/index.test.jsx
+++ b/src/components/Sidebar/Item/index.test.jsx
@@ -1,0 +1,229 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { HomeIcon, ProxyIcon } from '@/components/icons'
+
+import SidebarItem from './index'
+
+describe('SidebarItem', () => {
+  const mockSetActiveItem = jest.fn()
+
+  const simpleItem = {
+    name: 'Home',
+    icon: HomeIcon
+  }
+
+  const itemWithBadge = {
+    name: 'Dashboard',
+    icon: HomeIcon,
+    badge: '5'
+  }
+
+  const itemWithSubItems = {
+    name: 'Proxies',
+    icon: ProxyIcon,
+    subItems: [{ name: 'Residential', badge: '1' }, { name: 'ISP' }]
+  }
+
+  const externalItem = {
+    name: 'Documentation',
+    icon: HomeIcon,
+    external: true
+  }
+
+  beforeEach(() => {
+    mockSetActiveItem.mockClear()
+  })
+
+  it('renders item with icon and label', () => {
+    render(
+      <SidebarItem
+        item={simpleItem}
+        activeItem='Home'
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('shows notification badge when present', () => {
+    render(
+      <SidebarItem
+        item={itemWithBadge}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('applies active class when item is active', () => {
+    const { container } = render(
+      <SidebarItem
+        item={simpleItem}
+        activeItem='Home'
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const mainItem = container.querySelector('.sidebar-item__main')
+
+    expect(mainItem).toHaveClass('sidebar-item__main--active')
+  })
+
+  it('does not apply active class when item is not active', () => {
+    const { container } = render(
+      <SidebarItem
+        item={simpleItem}
+        activeItem='Other'
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const mainItem = container.querySelector('.sidebar-item__main')
+
+    expect(mainItem).not.toHaveClass('sidebar-item__main--active')
+  })
+
+  it('calls setActiveItem when simple item is clicked', async () => {
+    render(
+      <SidebarItem
+        item={simpleItem}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button)
+
+    expect(mockSetActiveItem).toHaveBeenCalledWith('Home')
+  })
+
+  it('does not call setActiveItem for external items', async () => {
+    render(
+      <SidebarItem
+        item={externalItem}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button)
+
+    expect(mockSetActiveItem).not.toHaveBeenCalled()
+  })
+
+  it('shows external icon for external items', () => {
+    render(
+      <SidebarItem
+        item={externalItem}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const externalIcon = document.querySelector(
+      '.sidebar-item__additional-icon'
+    )
+
+    expect(externalIcon).toBeInTheDocument()
+  })
+
+  it('toggles expansion when item with subItems is clicked', async () => {
+    const { container } = render(
+      <SidebarItem
+        item={itemWithSubItems}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: /proxies/i })
+    const submenu = container.querySelector('.sidebar-item__submenu')
+
+    expect(submenu).not.toHaveClass('sidebar-item__submenu--open')
+
+    await userEvent.click(button)
+
+    expect(submenu).toHaveClass('sidebar-item__submenu--open')
+
+    await userEvent.click(button)
+
+    expect(submenu).not.toHaveClass('sidebar-item__submenu--open')
+  })
+
+  it('renders sub-items when item has subItems', () => {
+    render(
+      <SidebarItem
+        item={itemWithSubItems}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    expect(screen.getByText('Residential')).toBeInTheDocument()
+    expect(screen.getByText('ISP')).toBeInTheDocument()
+  })
+
+  it('shows chevron icon for items with subItems', () => {
+    const { container } = render(
+      <SidebarItem
+        item={itemWithSubItems}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const chevronIcon = container.querySelector(
+      '.sidebar-item__additional-icon'
+    )
+
+    expect(chevronIcon).toBeInTheDocument()
+  })
+
+  it('rotates chevron icon when expanded', async () => {
+    const { container } = render(
+      <SidebarItem
+        item={itemWithSubItems}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: /proxies/i })
+    const chevronIcon = container.querySelector(
+      '.sidebar-item__additional-icon'
+    )
+
+    expect(chevronIcon).not.toHaveClass(
+      'sidebar-item__additional-icon--expanded'
+    )
+
+    await userEvent.click(button)
+
+    expect(chevronIcon).toHaveClass('sidebar-item__additional-icon--expanded')
+  })
+
+  it('calls setActiveItem when sub-item is clicked', async () => {
+    render(
+      <SidebarItem
+        item={itemWithSubItems}
+        activeItem=''
+        setActiveItem={mockSetActiveItem}
+      />
+    )
+
+    const subItemButton = screen.getByRole('button', { name: /residential/i })
+
+    await userEvent.click(subItemButton)
+
+    expect(mockSetActiveItem).toHaveBeenCalledWith('Residential')
+  })
+})

--- a/src/components/Sidebar/SubItem/index.test.jsx
+++ b/src/components/Sidebar/SubItem/index.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import SidebarSubItem from './index'
+
+describe('SidebarSubItem', () => {
+  const mockItem = {
+    name: 'Residential'
+  }
+
+  it('renders with label', () => {
+    render(
+      <SidebarSubItem item={mockItem} isActive={false} onClick={jest.fn()} />
+    )
+
+    expect(screen.getByText('Residential')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('shows notification badge when present', () => {
+    const itemWithBadge = { ...mockItem, badge: '3' }
+
+    render(
+      <SidebarSubItem
+        item={itemWithBadge}
+        isActive={false}
+        onClick={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('applies active class when isActive is true', () => {
+    const { container } = render(
+      <SidebarSubItem item={mockItem} isActive onClick={jest.fn()} />
+    )
+
+    const subItem = container.querySelector('.sidebar-sub-item')
+
+    expect(subItem).toHaveClass('sidebar-sub-item--active')
+  })
+
+  it('does not apply active class when isActive is false', () => {
+    const { container } = render(
+      <SidebarSubItem item={mockItem} isActive={false} onClick={jest.fn()} />
+    )
+
+    const subItem = container.querySelector('.sidebar-sub-item')
+
+    expect(subItem).not.toHaveClass('sidebar-sub-item--active')
+  })
+
+  it('calls onClick when button is clicked', async () => {
+    const handleClick = jest.fn()
+
+    render(
+      <SidebarSubItem item={mockItem} isActive={false} onClick={handleClick} />
+    )
+
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button)
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/Sidebar/index.test.jsx
+++ b/src/components/Sidebar/index.test.jsx
@@ -1,0 +1,72 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { renderWithProviders } from '@/tests'
+
+import AppSidebar from './index'
+
+describe('AppSidebar', () => {
+  it('renders all menu items', () => {
+    renderWithProviders(<AppSidebar isOpen />)
+
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Proxies')).toBeInTheDocument()
+    expect(screen.getByText('Documentation')).toBeInTheDocument()
+    expect(screen.getByText('User settings & preferences')).toBeInTheDocument()
+  })
+
+  it('renders sub-items for Proxies', () => {
+    renderWithProviders(<AppSidebar isOpen />)
+
+    expect(screen.getByText('Residential')).toBeInTheDocument()
+    expect(screen.getByText('ISP')).toBeInTheDocument()
+    expect(screen.getByText('SERP API')).toBeInTheDocument()
+  })
+
+  it('applies collapsed class when isOpen is false', () => {
+    const { container } = renderWithProviders(<AppSidebar isOpen={false} />)
+
+    const sidebar = container.querySelector('.app-sidebar')
+
+    expect(sidebar).toHaveClass('app-sidebar--collapsed')
+  })
+
+  it('does not apply collapsed class when isOpen is true', () => {
+    const { container } = renderWithProviders(<AppSidebar isOpen />)
+
+    const sidebar = container.querySelector('.app-sidebar')
+
+    expect(sidebar).not.toHaveClass('app-sidebar--collapsed')
+  })
+
+  it('sets Home as initial active item', () => {
+    renderWithProviders(<AppSidebar isOpen />)
+
+    const homeButton = screen.getByRole('button', { name: /home/i })
+    const activeItem = homeButton.closest('.sidebar-item__main')
+
+    expect(activeItem).toHaveClass('sidebar-item__main--active')
+  })
+
+  it('changes active item when clicked', async () => {
+    renderWithProviders(<AppSidebar isOpen />)
+
+    const residentialButton = screen.getByRole('button', {
+      name: /residential/i
+    })
+
+    await userEvent.click(residentialButton)
+
+    const activeSubItem = residentialButton.closest('.sidebar-sub-item')
+
+    expect(activeSubItem).toHaveClass('sidebar-sub-item--active')
+  })
+
+  it('renders copyright in footer', () => {
+    renderWithProviders(<AppSidebar isOpen />)
+
+    const footer = document.querySelector('.app-sidebar__footer')
+
+    expect(footer).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
1. [Feature]: Add dynamic menu items via `items` prop for role-based Sidebar rendering
2. [Feature]: Create `useSidebarMenu` hook for automatic menu selection by user role
3. [Feature]: Add menu configuration with `userMenuItems`, `adminMenuItems`, and `menuByRole`
4. [Feature]: Add BookOpen, Dashboard, and UsersIcon components for menu items
5. [Improvement]: Implement barrel file pattern with Sidebar.jsx and index.jsx exports
6. [Improvement]: Add `aria-current="page"` to active items for screen reader accessibility
7. [Refactor]: Consolidate Sidebar tests into `__tests__/` folder with descriptive names