### PR TITLE
Fix Docker cleanup workflow race condition

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -14,17 +14,9 @@ jobs:
     steps:
       - name: Delete old untagged images
         uses: actions/delete-package-versions@v5
+        continue-on-error: true
         with:
           package-name: 'smela-front-ci'
           package-type: 'container'
           min-versions-to-keep: 8
           delete-only-untagged-versions: true
-
-      - name: Delete old feature branch tagged images
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: 'smela-front-ci'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          ignore-versions: '^(dev|main|dev-.*|main-.*)$'
-          delete-only-pre-release-versions: false


### PR DESCRIPTION
Resolves #35

- Add continue-on-error to handle race condition in delete action
- Remove ineffective second cleanup step that wasn't deleting anything
- Simplify workflow to single step that keeps 8 most recent untagged versions

The workflow was actually working correctly but failing with "Package not found" error after successful bulk deletion due to stale package ID references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)