### PR TITLE
Remove hover and focus styles from Sun icon

### DIFF
--- a/src/components/icons/Sun/styles.scss
+++ b/src/components/icons/Sun/styles.scss
@@ -3,9 +3,4 @@
 
 .sun-icon--primary {
   color: var(--orange);
-
-  &:hover,
-  &:focus {
-    color: var(--button-primary-accent);
-  }
 }


### PR DESCRIPTION
1. [Improvement]: Remove hover/focus color change from Sun theme toggle icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)