### PR TITLE
Use purple-tinted glow for dark theme shadow

### DIFF
--- a/src/styles/theme/dark.scss
+++ b/src/styles/theme/dark.scss
@@ -34,5 +34,5 @@
   --link-accent: #8b8df5;
 
   // Shadow color
-  --shadow-color: rgb(255 255 255 / 15%);
+  --shadow-color: rgb(139 92 246 / 10%);
 }


### PR DESCRIPTION
1. [Improvement]: Replace white shadow with purple-tinted glow for natural dark theme elevation