### PR TITLE
Update admin email and generalize test docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ All pnpm scripts are defined in `package.json`. Key workflows:
 - Unit tests: `ut` (all tests), `ut:cov` (with coverage)
 - E2E tests: `e2e` (headless), `e2e:ui` (interactive mode)
 - Run single test: `pnpm run ut -- path/to/test.spec.js`
-- E2E tests require pre-registered `jason@example.com` account
+- E2E tests require pre-registered admin and user accounts
 
 ### Code Quality
 
@@ -108,8 +108,8 @@ Translation files (`public/locales/*.json`) follow entity-based organization:
 
 - **Entity cohesion**: Group related data together (e.g., `name` + `values`)
 - **Single source of truth**: Define labels once, reference with `$t()`
-- **No fragmentation**: Avoid separate objects like `filters.role` when `role.name`
-  exists
+- **No fragmentation**: Avoid separate objects like `filters.role` when
+  `role.name` exists
 
 ```json
 // Entity pattern

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,9 +2,8 @@
 
 ## ⚠️ Prerequisites
 
-Before running the tests, make sure the `jason@example.com` account is
-registered. This account is used in tests that validate "email already in use"
-error on signup.
+Before running the tests, make sure pre-registered accounts are seeded into the
+database.
 
 ## 📦 Setup
 

--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -121,7 +121,7 @@ test.describe.serial('Authentication', () => {
     await expect(passwordInput).toHaveClass(/input__field--error/)
   })
 
-  // This test requires seed data with jason@example.com
+  // This test requires a pre-registered admin account
   test('signup: prevents duplicate email registration', async ({ page }) => {
     await page.goto('/signup')
 

--- a/src/tests/data/auth.js
+++ b/src/tests/data/auth.js
@@ -27,7 +27,7 @@ export const auth = {
   },
   email: {
     ok: 'example@example.com',
-    admin: 'jason@example.com',
+    admin: 'slava.admin@smela.com',
     invalid: 'examp@',
     noAt: 'example.com',
     noDomain: 'example@',


### PR DESCRIPTION
1. [Improvement]: Update admin email from jason@example.com to slava.admin@smela.com
2. [Improvement]: Generalize test documentation to avoid hardcoded email references