### PR TITLE
Rename service modules to use Api suffix

### DIFF
--- a/src/hooks/useAdmin.js
+++ b/src/hooks/useAdmin.js
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import { defaultOptions } from '@/components/Pagination'
-import { adminService } from '@/services/backend'
+import { adminApi } from '@/services/backend'
 
 export const adminKeys = {
   all: () => ['admin'],
@@ -21,7 +21,7 @@ const adminQueryOptions = {
 export const useUsers = (params = {}) => {
   return useQuery({
     queryKey: adminKeys.usersList(params),
-    queryFn: () => adminService.getUsers(params),
+    queryFn: () => adminApi.getUsers(params),
     select: data => ({
       users: data?.users ?? [],
       pagination: data?.pagination ?? defaultOptions
@@ -34,7 +34,7 @@ export const useUsers = (params = {}) => {
 export const useUser = (id, options = {}) => {
   return useQuery({
     queryKey: adminKeys.userDetail(id),
-    queryFn: () => adminService.getUserById(id),
+    queryFn: () => adminApi.getUserById(id),
     enabled: !!id,
     ...adminQueryOptions,
     ...options

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { accessTokenStorage } from '@/lib/storage'
-import { authService, userService } from '@/services/backend'
+import { authApi, userApi } from '@/services/backend'
 import {
   clearUser as clearErrorTrackerUser,
   setUser as setErrorTrackerUser
@@ -17,7 +17,7 @@ export const useCurrentUser = () => {
 
   const query = useQuery({
     queryKey: authKeys.user(),
-    queryFn: userService.getCurrentUser,
+    queryFn: userApi.getCurrentUser,
     select: data => data.user,
     enabled: hasAccessToken
   })
@@ -37,7 +37,7 @@ export const useLogin = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.logIn,
+    mutationFn: authApi.logIn,
     onSuccess: data => {
       accessTokenStorage.set(data.accessToken)
 
@@ -71,7 +71,7 @@ export const useUserSignupWithEmail = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.signUp,
+    mutationFn: authApi.signUp,
     onSuccess: data => {
       accessTokenStorage.set(data.accessToken)
 
@@ -105,7 +105,7 @@ export const useLogout = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.logOut,
+    mutationFn: authApi.logOut,
     meta: {
       invalidatesQueries: authKeys.all()
     },
@@ -123,7 +123,7 @@ export const useVerifyEmail = ({ onSettled }) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.verifyEmail,
+    mutationFn: authApi.verifyEmail,
     onSuccess: data => {
       accessTokenStorage.set(data.accessToken)
 
@@ -144,19 +144,19 @@ export const useVerifyEmail = ({ onSettled }) => {
 
 export const useResendVerificationEmail = () =>
   useMutation({
-    mutationFn: authService.resendVerificationEmail
+    mutationFn: authApi.resendVerificationEmail
   })
 
 export const useRequestPasswordReset = () =>
   useMutation({
-    mutationFn: authService.requestPasswordReset
+    mutationFn: authApi.requestPasswordReset
   })
 
 export const useResetPassword = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.resetPassword,
+    mutationFn: authApi.resetPassword,
     onSuccess: data => {
       accessTokenStorage.set(data.accessToken)
 
@@ -178,7 +178,7 @@ export const useAcceptInvite = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: authService.acceptInvite,
+    mutationFn: authApi.acceptInvite,
     onSuccess: data => {
       accessTokenStorage.set(data.accessToken)
 
@@ -199,7 +199,7 @@ export const useUpdateUser = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: userService.updateUser,
+    mutationFn: userApi.updateUser,
     onMutate: async newUserData => {
       // Cancel any in-flight queries for the user
       await queryClient.cancelQueries({ queryKey: authKeys.user() })

--- a/src/hooks/useOwner.js
+++ b/src/hooks/useOwner.js
@@ -6,7 +6,7 @@ import {
 } from '@tanstack/react-query'
 
 import { defaultOptions } from '@/components/Pagination'
-import { ownerService } from '@/services/backend'
+import { ownerApi } from '@/services/backend'
 
 export const ownerKeys = {
   all: () => ['owner'],
@@ -25,7 +25,7 @@ const ownerQueryOptions = {
 export const useAdmins = (params = {}) => {
   return useQuery({
     queryKey: ownerKeys.adminsList(params),
-    queryFn: () => ownerService.getAdmins(params),
+    queryFn: () => ownerApi.getAdmins(params),
     select: data => ({
       admins: data?.admins ?? [],
       pagination: data?.pagination ?? defaultOptions
@@ -39,7 +39,7 @@ export const useInviteAdmin = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ownerService.inviteAdmin,
+    mutationFn: ownerApi.inviteAdmin,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ownerKeys.admins() })
     }

--- a/src/services/backend/admin.js
+++ b/src/services/backend/admin.js
@@ -3,7 +3,7 @@ import { withQuery } from '@/lib/url'
 import apiClient from './apiClient'
 import { ADMIN_USERS_PATH } from './paths'
 
-const adminService = {
+export const adminApi = {
   getUsers(params) {
     return apiClient.get(withQuery(ADMIN_USERS_PATH, params))
   },
@@ -12,5 +12,3 @@ const adminService = {
     return apiClient.get(`${ADMIN_USERS_PATH}/${id}`)
   }
 }
-
-export default adminService

--- a/src/services/backend/auth.js
+++ b/src/services/backend/auth.js
@@ -10,7 +10,7 @@ import {
   VERIFY_EMAIL_PATH
 } from './paths'
 
-const authService = {
+export const authApi = {
   signUp(data) {
     return apiClient.post(SIGNUP_PATH, data)
   },
@@ -43,5 +43,3 @@ const authService = {
     return apiClient.post(LOGOUT_PATH)
   }
 }
-
-export default authService

--- a/src/services/backend/index.js
+++ b/src/services/backend/index.js
@@ -1,4 +1,4 @@
-export { default as adminService } from './admin'
-export { default as authService } from './auth'
-export { default as ownerService } from './owner'
-export { default as userService } from './user'
+export { adminApi } from './admin'
+export { authApi } from './auth'
+export { ownerApi } from './owner'
+export { userApi } from './user'

--- a/src/services/backend/owner.js
+++ b/src/services/backend/owner.js
@@ -3,7 +3,7 @@ import { withQuery } from '@/lib/url'
 import apiClient from './apiClient'
 import { OWNER_ADMINS_INVITE_PATH, OWNER_ADMINS_PATH } from './paths'
 
-const ownerService = {
+export const ownerApi = {
   getAdmins(params) {
     return apiClient.get(withQuery(OWNER_ADMINS_PATH, params))
   },
@@ -12,5 +12,3 @@ const ownerService = {
     return apiClient.post(OWNER_ADMINS_INVITE_PATH, data)
   }
 }
-
-export default ownerService

--- a/src/services/backend/user.js
+++ b/src/services/backend/user.js
@@ -1,7 +1,7 @@
 import apiClient from './apiClient'
 import { ME_PATH } from './paths'
 
-const userService = {
+export const userApi = {
   getCurrentUser() {
     return apiClient.get(ME_PATH)
   },
@@ -10,5 +10,3 @@ const userService = {
     return apiClient.post(ME_PATH, data)
   }
 }
-
-export default userService


### PR DESCRIPTION
1. [Refactor]: Rename adminService, authService, ownerService, userService to *Api naming
2. [Refactor]: Update barrel exports in services/backend/index.js
3. [Refactor]: Update all hook imports and usages across useAdmin, useAuth, useOwner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal API structure for improved code maintainability. All functionality remains unchanged with no impact to user-facing features or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->