### PR TITLE
Fix Storybook theme toolbar sync with ThemeProvider

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -27,7 +27,7 @@ const preview = {
   globalTypes: {
     theme: {
       name: 'Theme',
-      defaultValue: 'light',
+      defaultValue: 'dark',
       toolbar: {
         icon: 'contrast',
         title: 'Theme',
@@ -59,11 +59,6 @@ const preview = {
     (Story, context) => {
       const { theme, locale } = context.globals
 
-      const isDark = theme === 'dark'
-
-      // toggle `dark` class on <html>
-      document.documentElement.classList.toggle('dark', isDark)
-
       // Set i18n language
       if (locale) {
         i18n.changeLanguage(locale)
@@ -73,14 +68,13 @@ const preview = {
 
       return (
         <MemoryRouter initialEntries={[initialPath]}>
-          <ThemeProvider>
-            <LocaleProvider>
+          {/* Key forces ThemeProvider remount when toolbar theme changes */}
+          <ThemeProvider key={theme} initialTheme={theme}>
+            <LocaleProvider key={locale}>
               <NotificationProvider>
                 <ModalProvider>
-                  {/* SidebarProvider is extra for Storybook only */}
                   <SidebarProvider>
-                    {/* Use key to force re-render when locale & theme changes */}
-                    <Story key={`${locale}-${theme}`} />
+                    <Story />
                   </SidebarProvider>
                 </ModalProvider>
               </NotificationProvider>

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -20,8 +20,8 @@ const getInitialTheme = () => {
   return prefersDark ? 'dark' : 'light'
 }
 
-export const ThemeProvider = ({ children }) => {
-  const [theme, setTheme] = useState(getInitialTheme)
+export const ThemeProvider = ({ children, initialTheme }) => {
+  const [theme, setTheme] = useState(() => initialTheme ?? getInitialTheme())
 
   useEffect(() => {
     localStorage.set(THEME_STORAGE_KEY, theme)


### PR DESCRIPTION
1. [Fix]: Sync Storybook toolbar theme selection with ThemeProvider state
2. [Improvement]: Add initialTheme prop to ThemeProvider for external control
3. [Fix]: Force provider remount on theme/locale change via React key prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Storybook now defaults to dark theme instead of light.
  * Enhanced theme and locale switching mechanism to ensure consistent updates across all components when preferences change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->