### PR TITLE
Fix horizontal overflow and add max-width to content area

### DIFF
--- a/src/components/ui/sidebar.jsx
+++ b/src/components/ui/sidebar.jsx
@@ -279,7 +279,7 @@ function SidebarInset({ className, ...props }) {
     <main
       data-slot='sidebar-inset'
       className={cn(
-        'bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col',
+        'bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex min-w-0 w-full flex-1 flex-col',
         className
       )}
       {...props}

--- a/src/layouts/UserLayout.jsx
+++ b/src/layouts/UserLayout.jsx
@@ -20,7 +20,7 @@ export const UserLayout = () => {
             <Header />
           </header>
 
-          <main className='flex flex-col flex-1 overflow-auto p-4 md:px-8 md:py-6 '>
+          <main className='flex flex-col flex-1 overflow-auto p-4 md:px-8 md:py-6 lg:mx-auto lg:max-w-6xl lg:w-full'>
             <Suspense fallback={<Spinner />}>
               <Outlet />
             </Suspense>


### PR DESCRIPTION
1. [Fix]: Add min-w-0 to SidebarInset to contain horizontal overflow in flex layout
2. [Enhancement]: Cap content area width on large screens with centered max-w-6xl container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined sidebar layout behavior for improved responsiveness.
  * Enhanced main content container layout on large screens with better centering and spacing constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->