### PR TITLE
Update toast position to top-right with offset

### DIFF
--- a/src/components/notifications/Toaster.jsx
+++ b/src/components/notifications/Toaster.jsx
@@ -4,5 +4,5 @@ import useTheme from '@/hooks/useTheme'
 export const Toaster = () => {
   const { theme } = useTheme()
 
-  return <SonnerToaster theme={theme} position='top-center' closeButton />
+  return <SonnerToaster theme={theme} position='top-right' closeButton />
 }

--- a/src/components/ui/sonner.jsx
+++ b/src/components/ui/sonner.jsx
@@ -19,6 +19,7 @@ const Toaster = ({ theme = 'system', ...props }) => {
         error: <OctagonXIcon className='size-4 text-red-500' />,
         loading: <Loader2Icon className='size-4 animate-spin' />
       }}
+      offset={{ top: 60, right: 32 }}
       style={{
         '--normal-bg': 'var(--popover)',
         '--normal-text': 'var(--popover-foreground)',


### PR DESCRIPTION
1. [Improvement]: Move toast notifications to top-right for better sidebar compatibility
2. [Improvement]: Add 60px top and 32px right offset to position below header

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Toast notifications now appear in the top-right corner with adjusted spacing for improved visual layout and interface balance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->