### PR TITLE
Rename locale parameter to avoid variable shadowing

### DIFF
--- a/src/contexts/LocaleContext.jsx
+++ b/src/contexts/LocaleContext.jsx
@@ -28,10 +28,10 @@ export const LocaleProvider = ({ children }) => {
     document.documentElement.lang = locale
   }, [locale])
 
-  const changeLocale = useCallback(locale => {
-    setLocale(locale)
-    i18n.changeLanguage(locale)
-    storeLocale(locale)
+  const changeLocale = useCallback(newLocale => {
+    setLocale(newLocale)
+    i18n.changeLanguage(newLocale)
+    storeLocale(newLocale)
   }, [])
 
   const changeFormatPreference = useCallback((key, value) => {


### PR DESCRIPTION
1. [Refactor]: Rename `locale` parameter to `newLocale` in `changeLocale` callback to avoid shadowing outer state variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->