### PR TITLE
Fix top-right controls

### DIFF
--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -21,7 +21,7 @@ export const LayoutContent = ({ children, className }) => (
 export const LayoutTopRightControls = ({ children }) => (
   <div
     data-testid='layout-top-right-controls'
-    className='absolute top-4 right-4 z-10 flex gap-4 md:top-8 md:right-8'
+    className='absolute top-2 right-4 z-10 flex gap-4 md:top-4 md:right-8'
   >
     {children}
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical positioning of the top-right layout control on smaller and medium-sized screens, moving it closer to the top for improved visual spacing and alignment across different device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->