### PR TITLE
Exclude table components from React Compiler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,29 @@ custom backend API:
    - Trailing comments: Lowercase start, brief, no period (e.g.,
      `const i = 0 // initial value`)
 
+## Known Issues / FIXME
+
+### TanStack Table + React Compiler Incompatibility
+
+TanStack Table uses interior mutability which is incompatible with React
+Compiler's memoization assumptions. See:
+https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
+
+**Current workarounds:**
+
+1. Always use the ESLint disable comment when calling `useReactTable`:
+
+   ```jsx
+   // eslint-disable-next-line react-hooks/incompatible-library
+   const table = useReactTable({
+   ```
+
+2. React Compiler is disabled for `src/components/table/` in `vite.config.js`
+   (fixed column visibility dropdown in PR #158)
+
+**Tracking:** Issue #149 - Update TanStack Table when compatible version is
+released.
+
 ## Important Considerations
 
 - The app supports English and Ukrainian languages

--- a/src/components/table/Table.stories.jsx
+++ b/src/components/table/Table.stories.jsx
@@ -76,8 +76,6 @@ const columns = [
 const InteractiveTable = ({ data, onRowClick }) => {
   const [sorting, setSorting] = useState([])
 
-  // TanStack Table uses interior mutability which is incompatible with React Compiler's memoization.
-  // See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({
     data,

--- a/src/pages/admin/Team/Members/Members.jsx
+++ b/src/pages/admin/Team/Members/Members.jsx
@@ -39,8 +39,6 @@ export const Members = ({ teamId, members }) => {
     })
   }
 
-  // TanStack Table uses interior mutability which is incompatible with React Compiler's memoization.
-  // See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({
     data: members,

--- a/src/pages/admin/Teams/TeamsPage.jsx
+++ b/src/pages/admin/Teams/TeamsPage.jsx
@@ -75,8 +75,6 @@ export const TeamsPage = () => {
     setParams({ limit }, { resetPage: true })
   }
 
-  // TanStack Table uses interior mutability which is incompatible with React Compiler's memoization.
-  // See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({
     data: teams,

--- a/src/pages/admin/Users/UsersPage.jsx
+++ b/src/pages/admin/Users/UsersPage.jsx
@@ -72,8 +72,6 @@ export const UsersPage = () => {
     setParams({ limit }, { resetPage: true })
   }
 
-  // TanStack Table uses interior mutability which is incompatible with React Compiler's memoization.
-  // See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({
     data: users,

--- a/src/pages/owner/Admins/AdminsPage.jsx
+++ b/src/pages/owner/Admins/AdminsPage.jsx
@@ -100,8 +100,6 @@ export const AdminsPage = () => {
     setParams({ limit }, { resetPage: true })
   }
 
-  // TanStack Table uses interior mutability which is incompatible with React Compiler's memoization.
-  // See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({
     data: admins,

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,14 @@ const __dirname = path.dirname(__filename)
 const isProdOrStage =
   process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging'
 
+// TanStack Table uses interior mutability: it modifies config objects in place
+// while keeping the same reference. React Compiler assumes immutable props and
+// memoizes based on reference equality, so these mutations go undetected.
+// Excluding table components forces React to re-render them normally.
+const reactCompilerOptions = {
+  sources: filename => !filename.includes('src/components/table/')
+}
+
 export default defineConfig({
   build: {
     sourcemap: isProdOrStage ? 'hidden' : true,
@@ -38,21 +46,7 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [
-          [
-            'babel-plugin-react-compiler',
-            {
-              sources: filename => {
-                // Exclude Table components due to TanStack Table's interior mutability
-                if (filename.includes('src/components/table/')) {
-                  return false
-                }
-
-                return true
-              }
-            }
-          ]
-        ]
+        plugins: [['babel-plugin-react-compiler', reactCompilerOptions]]
       }
     }),
     tailwindcss(),


### PR DESCRIPTION
1. [Fix]: Exclude src/components/table/ from React Compiler to fix TanStack Table reactivity
2. [Improvement]: Extract reactCompilerOptions before defineConfig for better readability
3. [Improvement]: Add Known Issues section to CLAUDE.md documenting the workaround

TanStack Table uses interior mutability which is incompatible with React Compiler's memoization. The table config object reference stays the same while internal state changes, causing the compiler to skip re-renders.

See: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library

**Tracking:** Issue SlavaMelanko/smela#84 - Update TanStack Table when compatible version is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration related to React compilation affecting table components.
* **Documentation**
  * Added a Known Issues / FIXME section describing a table/compiler incompatibility and two user-facing workarounds.
* **Style**
  * Removed several developer comment blocks from table and admin pages (no behavioral changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->