### PR TITLE
Rename company to team in react-artisan skill examples

### DIFF
--- a/.claude/skills/react-artisan/references/callback-naming.md
+++ b/.claude/skills/react-artisan/references/callback-naming.md
@@ -10,7 +10,7 @@
 const handleClick = () => navigate('/')
 const handleToggle = () => setVisible(!visible)
 const handlePageChange = page => setParams({ page })
-const handleSubmit = data => updateCompany(data)
+const handleSubmit = data => updateTeam(data)
 ```
 
 **Why this fails:**
@@ -29,7 +29,7 @@ Name functions by the action they perform.
 const navigateHome = () => navigate('/')
 const toggleVisibility = () => setVisible(!visible)
 const changePage = page => setParams({ page })
-const submit = data => updateCompany(data)
+const submit = data => updateTeam(data)
 ```
 
 ### Exception: TanStack Query Mutation Wrappers
@@ -61,7 +61,7 @@ This exception exists because mutation wrappers orchestrate side effects and the
 
 | Pattern | Name Style | Example |
 | --- | --- | --- |
-| Navigation | `navigateTo*` | `navigateHome`, `navigateToCompany` |
+| Navigation | `navigateTo*` | `navigateHome`, `navigateToTeam` |
 | Toggle state | `toggle*` | `toggleVisibility`, `toggleFilters` |
 | Open dialog/modal | `open*` | `openUserProfile`, `openInviteDialog` |
 | Form submission | `submit` | `submit` |

--- a/.claude/skills/react-artisan/references/composition-over-configuration.md
+++ b/.claude/skills/react-artisan/references/composition-over-configuration.md
@@ -7,7 +7,7 @@ principles and become maintenance nightmares.
 
 ```jsx
 // ❌ Avoid: monolithic component with inline markup and conditionals
-export const CompanyPageHeader = ({
+export const TeamPageHeader = ({
   name,
   website,
   description,
@@ -99,8 +99,8 @@ export const PageHeaderEmail = ({ email }) => {
 ## Usage: Compose What You Need
 
 ```jsx
-// Company page — uses website
-export const CompanyPageHeader = ({ name, website }) => (
+// Team page — uses website
+export const TeamPageHeader = ({ name, website }) => (
   <PageHeader>
     <PageHeaderIcon icon={Building2} />
     <PageHeaderContent>

--- a/.claude/skills/react-artisan/references/loading-state-patterns.md
+++ b/.claude/skills/react-artisan/references/loading-state-patterns.md
@@ -85,27 +85,27 @@ a retry after failure), showing the error is more informative than a spinner.
 
 ```jsx
 // When data is destructured to a named variable, use that name
-const CompanyPage = () => {
+const TeamPage = () => {
   const {
-    data: company,
+    data: team,
     isPending,
     isError,
     error,
     refetch
   } = useQuery({
-    queryKey: ['company', companyId],
-    queryFn: () => fetchCompany(companyId)
+    queryKey: ['team', teamId],
+    queryFn: () => fetchTeam(teamId)
   })
 
   if (isError) {
     return <ErrorState text={te(error)} onRetry={refetch} />
   }
 
-  if (isPending && !company) {
+  if (isPending && !team) {
     return <Spinner />
   }
 
-  return <CompanyDetails company={company} />
+  return <TeamDetails team={team} />
 }
 ```
 


### PR DESCRIPTION
1. [Improvement]: Update skill examples to use team/teams instead of company/companies for codebase consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in reference guides for callback naming conventions, component composition patterns, and loading state patterns to reflect revised best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->