### PR TITLE
Rename invite endpoints to use members pattern

### DIFF
--- a/e2e/owner.spec.js
+++ b/e2e/owner.spec.js
@@ -3,7 +3,6 @@ import { faker } from '@faker-js/faker'
 import { HttpStatus } from '../src/lib/net'
 import {
   ACCEPT_INVITE_PATH,
-  OWNER_ADMINS_INVITE_PATH,
   OWNER_ADMINS_PATH
 } from '../src/services/backend/paths'
 import { auth } from '../src/tests/data'
@@ -51,7 +50,7 @@ test.describe.serial('Owner: Admin Invitation', () => {
     ).toBeVisible()
 
     const apiPromises = waitForApiCalls(page, [
-      { path: OWNER_ADMINS_INVITE_PATH, status: HttpStatus.CREATED },
+      { path: OWNER_ADMINS_PATH, status: HttpStatus.CREATED },
       { path: OWNER_ADMINS_PATH, status: HttpStatus.OK }
     ])
 

--- a/src/services/backend/admin.js
+++ b/src/services/backend/admin.js
@@ -2,7 +2,7 @@ import { withQuery } from '@/lib/url'
 
 import apiClient from './apiClient'
 import {
-  ADMIN_TEAMS_INVITES_PATH,
+  ADMIN_TEAMS_MEMBERS_PATH,
   ADMIN_TEAMS_PATH,
   ADMIN_TEAMS_RESEND_INVITE_PATH,
   ADMIN_USERS_PATH
@@ -38,7 +38,7 @@ export const adminApi = {
   },
 
   inviteTeamMember(teamId, data) {
-    const url = ADMIN_TEAMS_INVITES_PATH.replace(':id', teamId)
+    const url = ADMIN_TEAMS_MEMBERS_PATH.replace(':id', teamId)
 
     return apiClient.post(url, data)
   },

--- a/src/services/backend/owner.js
+++ b/src/services/backend/owner.js
@@ -1,11 +1,7 @@
 import { withQuery } from '@/lib/url'
 
 import apiClient from './apiClient'
-import {
-  OWNER_ADMINS_INVITE_PATH,
-  OWNER_ADMINS_PATH,
-  OWNER_ADMINS_RESEND_INVITE_PATH
-} from './paths'
+import { OWNER_ADMINS_PATH, OWNER_ADMINS_RESEND_INVITE_PATH } from './paths'
 
 export const ownerApi = {
   getAdmins(params) {
@@ -13,7 +9,7 @@ export const ownerApi = {
   },
 
   inviteAdmin(data) {
-    return apiClient.post(OWNER_ADMINS_INVITE_PATH, data)
+    return apiClient.post(OWNER_ADMINS_PATH, data)
   },
 
   resendAdminInvitation(id) {

--- a/src/services/backend/paths.js
+++ b/src/services/backend/paths.js
@@ -17,12 +17,11 @@ export const ME_PATH = '/api/v1/user/me'
 // Admin endpoints
 export const ADMIN_USERS_PATH = '/api/v1/admin/users'
 export const ADMIN_TEAMS_PATH = '/api/v1/admin/teams'
-export const ADMIN_TEAMS_INVITES_PATH = '/api/v1/admin/teams/:id/invites'
+export const ADMIN_TEAMS_MEMBERS_PATH = '/api/v1/admin/teams/:id/members'
 export const ADMIN_TEAMS_RESEND_INVITE_PATH =
-  '/api/v1/admin/teams/:id/invites/:memberId/resend'
+  '/api/v1/admin/teams/:id/members/:memberId/resend-invite'
 
 // Owner endpoints
 export const OWNER_ADMINS_PATH = '/api/v1/owner/admins'
-export const OWNER_ADMINS_INVITE_PATH = '/api/v1/owner/admins/invites'
 export const OWNER_ADMINS_RESEND_INVITE_PATH =
-  '/api/v1/owner/admins/invites/:id/resend'
+  '/api/v1/owner/admins/:id/resend-invite'


### PR DESCRIPTION
1. [Improvement]: Rename `/invites` endpoints to `/members` for consistency with resource naming
2. [Improvement]: Change resend invite path from `/invites/:id/resend` to `/:id/resend-invite`
3. [Improvement]: Remove separate `OWNER_ADMINS_INVITE_PATH` - admin creation now uses `OWNER_ADMINS_PATH`

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated admin and team member invitation endpoints to use unified member management paths instead of separate invite endpoints.
  * Updated resend invitation endpoint paths to align with the new API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->