### PR TITLE
Extract context menu item factory helpers

### DIFF
--- a/src/components/table/contextMenuItems.js
+++ b/src/components/table/contextMenuItems.js
@@ -1,0 +1,33 @@
+import { MailIcon, Send, User, X } from 'lucide-react'
+
+import { UserStatus } from '@/lib/types'
+
+export const createOpenItem = (t, onClick, icon = User) => ({
+  icon,
+  label: t('contextMenu.open'),
+  onClick
+})
+
+export const createInviteItem = (
+  t,
+  { handleResendInvite, isResending, handleCancelInvite, isCancelling }
+) => ({
+  icon: MailIcon,
+  label: t('contextMenu.invite'),
+  isVisible: row => row.status === UserStatus.PENDING,
+  items: [
+    {
+      icon: Send,
+      label: t('contextMenu.resend'),
+      onClick: handleResendInvite,
+      disabled: isResending
+    },
+    {
+      icon: X,
+      label: t('contextMenu.cancel'),
+      onClick: handleCancelInvite,
+      variant: 'destructive',
+      disabled: isCancelling
+    }
+  ]
+})

--- a/src/pages/admin/Teams/TeamsPage.jsx
+++ b/src/pages/admin/Teams/TeamsPage.jsx
@@ -13,6 +13,7 @@ import { Pagination } from '@/components/Pagination'
 import { Spinner } from '@/components/Spinner'
 import { ErrorState } from '@/components/states'
 import { ColumnVisibilityDropdown, Table } from '@/components/table'
+import { createOpenItem } from '@/components/table/contextMenuItems'
 import { useLocale } from '@/hooks/useLocale'
 import { useTableState } from '@/hooks/useTableState'
 import { useTeams } from '@/hooks/useTeam'
@@ -43,13 +44,7 @@ export const TeamsPage = () => {
 
   const viewTeam = team => navigate(`/admin/teams/${team.id}`)
 
-  const contextMenu = [
-    {
-      icon: Users,
-      label: t('contextMenu.open'),
-      onClick: viewTeam
-    }
-  ]
+  const contextMenu = [createOpenItem(t, viewTeam, Users)]
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({

--- a/src/pages/admin/Users/UsersPage.jsx
+++ b/src/pages/admin/Users/UsersPage.jsx
@@ -4,7 +4,6 @@ import {
   getSortedRowModel,
   useReactTable
 } from '@tanstack/react-table'
-import { User } from 'lucide-react'
 import { useState } from 'react'
 
 import { ProfileDialog } from '@/components/dialogs'
@@ -12,6 +11,7 @@ import { Pagination } from '@/components/Pagination'
 import { Spinner } from '@/components/Spinner'
 import { ErrorState } from '@/components/states'
 import { Table } from '@/components/table'
+import { createOpenItem } from '@/components/table/contextMenuItems'
 import { useUsers } from '@/hooks/useAdmin'
 import { useLocale } from '@/hooks/useLocale'
 import { useModal } from '@/hooks/useModal'
@@ -48,13 +48,7 @@ export const UsersPage = () => {
     })
   }
 
-  const contextMenu = [
-    {
-      icon: User,
-      label: t('contextMenu.open'),
-      onClick: openUserProfile
-    }
-  ]
+  const contextMenu = [createOpenItem(t, openUserProfile)]
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({

--- a/src/pages/owner/Admins/AdminsPage.jsx
+++ b/src/pages/owner/Admins/AdminsPage.jsx
@@ -3,7 +3,6 @@ import {
   getSortedRowModel,
   useReactTable
 } from '@tanstack/react-table'
-import { MailIcon, Send, User, X } from 'lucide-react'
 import { useState } from 'react'
 
 import { InviteButton } from '@/components/buttons'
@@ -13,11 +12,14 @@ import { Pagination } from '@/components/Pagination'
 import { Spinner } from '@/components/Spinner'
 import { ErrorState } from '@/components/states'
 import { ColumnVisibilityDropdown, Table } from '@/components/table'
+import {
+  createInviteItem,
+  createOpenItem
+} from '@/components/table/contextMenuItems'
 import { useLocale } from '@/hooks/useLocale'
 import { useModal } from '@/hooks/useModal'
 import { useAdmins } from '@/hooks/useOwner'
 import { useTableState } from '@/hooks/useTableState'
-import { UserStatus } from '@/lib/types'
 import { PageContent } from '@/pages/Page'
 
 import { defaultHiddenColumns, getColumns } from './columns'
@@ -56,31 +58,13 @@ export const AdminsPage = () => {
   }
 
   const contextMenu = [
-    {
-      icon: User,
-      label: t('contextMenu.open'),
-      onClick: openAdminProfile
-    },
-    {
-      icon: MailIcon,
-      label: t('contextMenu.invite'),
-      isVisible: admin => admin.status === UserStatus.PENDING,
-      items: [
-        {
-          icon: Send,
-          label: t('contextMenu.resend'),
-          onClick: handleResendInvite,
-          disabled: isResending
-        },
-        {
-          icon: X,
-          label: t('contextMenu.cancel'),
-          onClick: handleCancelInvite,
-          variant: 'destructive',
-          disabled: isCancelling
-        }
-      ]
-    }
+    createOpenItem(t, openAdminProfile),
+    createInviteItem(t, {
+      handleResendInvite,
+      isResending,
+      handleCancelInvite,
+      isCancelling
+    })
   ]
 
   // eslint-disable-next-line react-hooks/incompatible-library

--- a/src/pages/shared/Team/Members/Members.jsx
+++ b/src/pages/shared/Team/Members/Members.jsx
@@ -1,5 +1,4 @@
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import { MailIcon, Send, User, X } from 'lucide-react'
 import { useState } from 'react'
 
 import { InviteButton } from '@/components/buttons'
@@ -7,10 +6,13 @@ import { ProfileDialog } from '@/components/dialogs'
 import { Spinner } from '@/components/Spinner'
 import { EmptyState, ErrorState } from '@/components/states'
 import { ColumnVisibilityDropdown, Table } from '@/components/table'
+import {
+  createInviteItem,
+  createOpenItem
+} from '@/components/table/contextMenuItems'
 import { useLocale } from '@/hooks/useLocale'
 import { useModal } from '@/hooks/useModal'
 import { useTeamMembers } from '@/hooks/useTeam'
-import { UserStatus } from '@/lib/types'
 
 import { defaultHiddenColumns, getColumns } from './columns'
 import { useInvite } from './useInvite'
@@ -50,31 +52,13 @@ export const Members = ({ teamId }) => {
   }
 
   const contextMenu = [
-    {
-      icon: User,
-      label: t('contextMenu.open'),
-      onClick: openMemberProfile
-    },
-    {
-      icon: MailIcon,
-      label: t('contextMenu.invite'),
-      isVisible: member => member.status === UserStatus.PENDING,
-      items: [
-        {
-          icon: Send,
-          label: t('contextMenu.resend'),
-          onClick: handleResendInvite,
-          disabled: isResending
-        },
-        {
-          icon: X,
-          label: t('contextMenu.cancel'),
-          onClick: handleCancelInvite,
-          variant: 'destructive',
-          disabled: isCancelling
-        }
-      ]
-    }
+    createOpenItem(t, openMemberProfile),
+    createInviteItem(t, {
+      handleResendInvite,
+      isResending,
+      handleCancelInvite,
+      isCancelling
+    })
   ]
 
   const columns = getColumns(t, formatDate)


### PR DESCRIPTION
1. [Improvement]: Add `createOpenItem` and `createInviteItem` factory functions in a new `contextMenuItems.js` module
2. [Improvement]: Remove duplicated inline context menu literals from TeamsPage, UsersPage, AdminsPage, and Members
3. [Improvement]: Centralize icon, label, and visibility logic for context menu items in one place