### PR TITLE
Fix edit team name E2E test reliability

### DIFF
--- a/e2e/scenarios/team.js
+++ b/e2e/scenarios/team.js
@@ -19,9 +19,7 @@ export const fillTeamAddFormAndSubmit = async (
 export const updateTeamNameAndSubmit = async (page, newName, t) => {
   const nameInput = page.getByLabel(t.team.name.label)
 
-  await nameInput.click()
-  await nameInput.fill('')
-  await nameInput.pressSequentially(newName)
+  await nameInput.fill(newName)
 
   await page.getByRole('button', { name: t.save }).click()
 }

--- a/e2e/utils/api.js
+++ b/e2e/utils/api.js
@@ -3,7 +3,7 @@ import { test } from '@playwright/test'
 export const waitForApiCall = async (page, options, timeout = 30000) => {
   const { path, status, method, validateResponse, validateRequest } = options
 
-  return test.step(`Waiting for ${path}`, async () => {
+  return test.step(`Waiting for ${method} ${path}`, async () => {
     const response = await page.waitForResponse(
       async response => {
         let matches = response.url().includes(path)


### PR DESCRIPTION
1. [Fix]: Capture team id from POST response to use precise API paths in assertions
2. [Fix]: Wait for team detail GET before editing to avoid RHF reset race condition
3. [Fix]: Use `waitForApiCalls` to await both PATCH and invalidation GET after update
4. [Improvement]: Include HTTP method in `waitForApiCall` step label for clearer test logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced team management end-to-end tests with improved API synchronization for team creation and updates.
  * Refined team name editing interactions for more reliable test execution.
  * Updated test step descriptions for clearer visibility during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->